### PR TITLE
Persist WhatsApp message read-state and add mark-as-read endpoint

### DIFF
--- a/src/controllers/whatsappController.js
+++ b/src/controllers/whatsappController.js
@@ -1064,6 +1064,97 @@ const getMessages = asyncHandler(async (req, res) => {
   return res.json(payload);
 });
 
+const listConversations = asyncHandler(async (req, res) => {
+  const page = Math.max(1, Number(req.query.page) || 1);
+  const limit = Math.min(200, Math.max(1, Number(req.query.limit) || 50));
+  const skip = (page - 1) * limit;
+
+  const conversationPipeline = [
+    {
+      $addFields: {
+        conversationPhone: {
+          $cond: [
+            { $or: [{ $eq: ['$direction', 'incoming'] }, { $eq: ['$fromMe', false] }] },
+            '$from',
+            '$to',
+          ],
+        },
+        eventTime: { $ifNull: ['$timestamp', { $ifNull: ['$time', '$createdAt'] }] },
+        readState: {
+          $ifNull: ['$isRead', { $eq: ['$status', 'read'] }],
+        },
+      },
+    },
+    {
+      $match: {
+        conversationPhone: { $nin: [null, ''] },
+      },
+    },
+    {
+      $addFields: {
+        unreadFlag: {
+          $cond: [
+            {
+              $and: [
+                { $or: [{ $eq: ['$direction', 'incoming'] }, { $eq: ['$fromMe', false] }] },
+                { $ne: ['$readState', true] },
+              ],
+            },
+            1,
+            0,
+          ],
+        },
+      },
+    },
+    { $sort: { eventTime: -1, createdAt: -1 } },
+    {
+      $group: {
+        _id: '$conversationPhone',
+        lastMessageAt: { $first: '$eventTime' },
+        lastMessage: { $first: '$message' },
+        lastMessageType: { $first: '$type' },
+        unreadCount: { $sum: '$unreadFlag' },
+      },
+    },
+    {
+      $project: {
+        _id: 0,
+        conversationPhone: '$_id',
+        normalizedPhone: {
+          $regexReplace: {
+            input: '$_id',
+            regex: '[^0-9]',
+            replacement: '',
+          },
+        },
+        lastMessageAt: 1,
+        lastMessage: 1,
+        lastMessageType: 1,
+        unreadCount: 1,
+      },
+    },
+    { $sort: { lastMessageAt: -1, normalizedPhone: 1 } },
+  ];
+
+  const [totalAgg, conversations] = await Promise.all([
+    Message.aggregate([...conversationPipeline, { $count: 'total' }]),
+    Message.aggregate([...conversationPipeline, { $skip: skip }, { $limit: limit }]),
+  ]);
+
+  const total = totalAgg?.[0]?.total || 0;
+
+  return res.status(200).json({
+    success: true,
+    data: conversations,
+    pagination: {
+      page,
+      limit,
+      total,
+      hasMore: skip + conversations.length < total,
+    },
+  });
+});
+
 const markConversationRead = asyncHandler(async (req, res) => {
   const conversationPhone = String(
     req.body?.conversationPhone || req.body?.chatWith || req.query?.conversationPhone || ''
@@ -1421,6 +1512,7 @@ module.exports = {
   getAutoReplyRules,
   getTemplates,
   getMessages,
+  listConversations,
   markConversationRead,
   getAnalytics,
   verifyWebhook,

--- a/src/controllers/whatsappController.js
+++ b/src/controllers/whatsappController.js
@@ -47,6 +47,37 @@ const RESOLVED_API_VERSION = WHATSAPP_API_VERSION || 'v19.0';
 const normalizePhone = (to) => String(to || '').replace(/\D/g, '');
 const MESSAGE_TYPES = new Set(['text', 'image', 'document', 'template']);
 
+const resolveConversationIdentifiers = (rawPhone) => {
+  const raw = String(rawPhone || '').trim();
+  const digits = normalizePhone(raw);
+  if (!raw && !digits) return [];
+  return [...new Set([raw, digits].filter(Boolean))];
+};
+
+const buildConversationFilter = (rawPhone) => {
+  const identifiers = resolveConversationIdentifiers(rawPhone);
+  if (identifiers.length === 0) return {};
+
+  return {
+    $or: [
+      { from: { $in: identifiers } },
+      { to: { $in: identifiers } },
+    ],
+  };
+};
+
+const buildUnreadIncomingFilter = (baseFilter = {}) => ({
+  $and: [
+    baseFilter,
+    {
+      $or: [{ direction: 'incoming' }, { fromMe: false }],
+    },
+    {
+      $or: [{ isRead: false }, { isRead: { $exists: false }, status: { $ne: 'read' } }],
+    },
+  ],
+});
+
 const ensureWhatsAppMessagingConfig = () => {
   const config = validateWhatsAppConfig();
   if (!config.ok) {
@@ -563,6 +594,16 @@ const persistStatusEvents = async (statusEvents = []) => {
 
     const timestamp = parseStatusTimestamp(statusEvent?.timestamp);
     const campaignId = String(statusEvent?.conversation?.id || '').trim();
+    const messageUpdateSet = {
+      status,
+      timestamp,
+      time: timestamp,
+    };
+
+    if (status === 'read') {
+      messageUpdateSet.isRead = true;
+      messageUpdateSet.readAt = timestamp;
+    }
 
     statusOps.push({
       updateOne: {
@@ -576,11 +617,7 @@ const persistStatusEvents = async (statusEvents = []) => {
       updateOne: {
         filter: { messageId },
         update: {
-          $set: {
-            status,
-            timestamp,
-            time: timestamp,
-          },
+          $set: messageUpdateSet,
         },
       },
     });
@@ -970,6 +1007,7 @@ const getMessages = asyncHandler(async (req, res) => {
   const sortOrder = String(req.query.sort || '').toLowerCase();
   const includeUiFields = String(req.query.includeUiFields || '').toLowerCase() === 'true';
   const includeUnreadCount = String(req.query.includeUnreadCount || '').toLowerCase() === 'true';
+  const conversationPhone = String(req.query.conversationPhone || req.query.chatWith || '').trim();
   const hasPaging = req.query.page !== undefined || req.query.limit !== undefined;
   const page = Math.max(1, Number(req.query.page) || 1);
   const limit = hasPaging ? Math.min(200, Math.max(1, Number(req.query.limit) || 50)) : null;
@@ -980,21 +1018,17 @@ const getMessages = asyncHandler(async (req, res) => {
     ? { timestamp: -1, time: -1, createdAt: -1 }
     : { timestamp: 1, time: 1, createdAt: 1 };
 
-  const messageQuery = Message.find({}).sort(sort);
+  const baseFilter = buildConversationFilter(conversationPhone);
+  const messageQuery = Message.find(baseFilter).sort(sort);
   if (hasPaging && limit) {
     messageQuery.skip(skip).limit(limit);
   }
 
   const [rawMessages, total, unreadCount] = await Promise.all([
     messageQuery.lean(),
-    Message.countDocuments({}),
+    Message.countDocuments(baseFilter),
     includeUnreadCount
-      ? Message.countDocuments({
-          $and: [
-            { $or: [{ direction: 'incoming' }, { fromMe: false }] },
-            { status: { $ne: 'read' } },
-          ],
-        })
+      ? Message.countDocuments(buildUnreadIncomingFilter(baseFilter))
       : Promise.resolve(null),
   ]);
 
@@ -1028,6 +1062,36 @@ const getMessages = asyncHandler(async (req, res) => {
   }
 
   return res.json(payload);
+});
+
+const markConversationRead = asyncHandler(async (req, res) => {
+  const conversationPhone = String(
+    req.body?.conversationPhone || req.body?.chatWith || req.query?.conversationPhone || ''
+  ).trim();
+
+  if (!conversationPhone) {
+    throw new AppError('conversationPhone is required', 400);
+  }
+
+  const baseFilter = buildConversationFilter(conversationPhone);
+  const now = new Date();
+
+  const result = await Message.updateMany(buildUnreadIncomingFilter(baseFilter), {
+    $set: {
+      isRead: true,
+      readAt: now,
+      status: 'read',
+    },
+  });
+
+  const unreadCount = await Message.countDocuments(buildUnreadIncomingFilter(baseFilter));
+
+  return res.status(200).json({
+    success: true,
+    conversationPhone: normalizePhone(conversationPhone) || conversationPhone,
+    updatedCount: result.modifiedCount || result.nModified || 0,
+    unreadCount,
+  });
 });
 
 const verifyWebhook = (req, res) => {
@@ -1357,6 +1421,7 @@ module.exports = {
   getAutoReplyRules,
   getTemplates,
   getMessages,
+  markConversationRead,
   getAnalytics,
   verifyWebhook,
   receiveWebhook,

--- a/src/repositories/Message.js
+++ b/src/repositories/Message.js
@@ -21,6 +21,14 @@ const messageSchema = new mongoose.Schema(
     time: Date,
     customerUuid: String,
     customerId: String,
+    isRead: {
+      type: Boolean,
+      default: null,
+    },
+    readAt: {
+      type: Date,
+      default: null,
+    },
   },
   { timestamps: true }
 );
@@ -66,6 +74,17 @@ messageSchema.pre('save', function syncLegacyFields(next) {
     this.time = this.timestamp;
   }
 
+  if (this.fromMe === true || this.direction === 'outgoing') {
+    this.isRead = true;
+    if (!this.readAt) {
+      this.readAt = this.timestamp || this.time || new Date();
+    }
+  } else if (this.fromMe === false || this.direction === 'incoming') {
+    if (typeof this.isRead === 'undefined' || this.isRead === null) {
+      this.isRead = false;
+    }
+  }
+
   next();
 });
 
@@ -75,5 +94,6 @@ messageSchema.index({ timestamp: 1 });
 messageSchema.index({ time: -1 });
 messageSchema.index({ messageId: 1 }, { sparse: true });
 messageSchema.index({ customerUuid: 1 });
+messageSchema.index({ from: 1, to: 1, isRead: 1, timestamp: -1 });
 
 module.exports = mongoose.model('Message', messageSchema);

--- a/src/routes/WhatsAppCloud.js
+++ b/src/routes/WhatsAppCloud.js
@@ -22,6 +22,7 @@ const {
   getAutoReplyRules,
   receiveWebhook,
   getMessages,
+  listConversations,
   markConversationRead,
   getAnalytics,
 } = require('../controllers/whatsappController');
@@ -80,6 +81,7 @@ router.get('/templates', requireAuth, getTemplates);
 
 // ---------- Messages API ----------
 router.get('/messages', requireAuth, getMessages);
+router.get('/conversations', requireAuth, listConversations);
 router.patch('/messages/read', requireAuth, markConversationRead);
 router.get('/analytics', requireAuth, getAnalytics);
 

--- a/src/routes/WhatsAppCloud.js
+++ b/src/routes/WhatsAppCloud.js
@@ -22,6 +22,7 @@ const {
   getAutoReplyRules,
   receiveWebhook,
   getMessages,
+  markConversationRead,
   getAnalytics,
 } = require('../controllers/whatsappController');
 
@@ -79,6 +80,7 @@ router.get('/templates', requireAuth, getTemplates);
 
 // ---------- Messages API ----------
 router.get('/messages', requireAuth, getMessages);
+router.patch('/messages/read', requireAuth, markConversationRead);
 router.get('/analytics', requireAuth, getAnalytics);
 
 // ---------- Webhook (no auth) ----------


### PR DESCRIPTION
### Motivation
- The frontend hiding of unread badges is not durable across refreshes, polling, or multiple clients, so read-state must be persisted server-side to keep unread counts consistent.
- Ensure incoming Meta `read` status, webhook flow, and conversation-scoped APIs all reflect a single source of truth for unread counts.

### Description
- Added persistent read-state fields to messages by extending `Message` schema with `isRead` and `readAt` and setting sensible defaults in the `pre('save')` hook so outgoing messages are treated as read and incoming messages default to unread (`src/repositories/Message.js`).
- Added conversation normalization and filter helpers to the WhatsApp controller to compute conversation-scoped queries using both raw and digit-only identifiers (`resolveConversationIdentifiers`, `buildConversationFilter`, `buildUnreadIncomingFilter`) (`src/controllers/whatsappController.js`).
- Scoped `GET /api/whatsapp/messages` with query params `conversationPhone` or `chatWith` and made unread count compute off persistent `isRead` (with legacy fallback to `status !== 'read'`) so API returns consistent unread counts per conversation (`src/controllers/whatsappController.js`).
- Persist `read` status from Meta webhook processing so webhook-driven status events set `isRead` and `readAt` on message records when appropriate (`src/controllers/whatsappController.js`).
- Added a new endpoint `PATCH /api/whatsapp/messages/read` that marks incoming messages for a conversation as read and returns `updatedCount` and the fresh `unreadCount`, and wired it into routes (`src/routes/WhatsAppCloud.js`, `src/controllers/whatsappController.js`).

### Testing
- Ran static syntax checks with `node --check` on `src/controllers/whatsappController.js`, `src/routes/WhatsAppCloud.js`, and `src/repositories/Message.js`, and these checks passed.
- Attempted project test runner with `npm test -- --runInBand`, which exited with `Error: no test specified` because the repository has no configured test suite; no unit tests were executed.
- Manual sanity: code compiles and new route is exported and accessible in router files (lightweight validation performed via `node --check`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf3e65d958832a8507367a9b8defda)